### PR TITLE
Fix start button visibility after game ends

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,7 +67,15 @@ function App() {
           THIS IS A QUIZ WEBSITE
         </Typography>
 
-        {score === totalQuestions ? (
+        {gameover ? (
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "center",
+              padding: "20px",
+            }}
+            
+          {score === totalQuestions ? (
           <div
             style={{
               display: "flex",


### PR DESCRIPTION
Related to #4

Updates the condition for displaying the start button in the quiz app to ensure it appears after the game ends, allowing for immediate game restarts.
- Modifies the condition in `src/App.tsx` to display the start button when the `gameover` state is `true`, instead of checking if the score equals the total number of questions. This change ensures that the start button is consistently available for users to start a new game once the current game concludes, regardless of their final score.
